### PR TITLE
Update API calls to latest GIMP 2.99 versions

### DIFF
--- a/src/resynthesizer/drawable.c
+++ b/src/resynthesizer/drawable.c
@@ -93,9 +93,9 @@ return gimp_drawable_mask_intersect(d->drawable_id,
 
 
 
-gint          bpp(GimpDrawable *d)       { return gimp_drawable_bpp   (d); }
-gint          width    (GimpDrawable *d) { return gimp_drawable_width (d); }
-gint          height   (GimpDrawable *d) { return gimp_drawable_height(d); }
+gint           bpp      (GimpDrawable *d) { return gimp_drawable_get_bpp    (d); }
+gint           width    (GimpDrawable *d) { return gimp_drawable_get_width  (d); }
+gint           height   (GimpDrawable *d) { return gimp_drawable_get_height (d); }
 
 GimpImageType  imageType(GimpDrawable *d) { return gimp_drawable_type     (d); }
 gboolean       is_rgb(GimpDrawable *d)    { return gimp_drawable_is_rgb   (d); }
@@ -133,7 +133,7 @@ offsets(
   gint         *x,
   gint         *y )
 {
-  gimp_drawable_offsets( d, x, y );
+  gimp_drawable_get_offsets (d, x, y);
 }
 
 GimpDrawable *


### PR DESCRIPTION
The recent updates to GIMP 2.99 have the following API changes:

gimp_drawable_height -> gimp_drawable_get_height
gimp_drawable_width -> gimp_drawable_get_width
gimp_drawable_bpp -> gimp_drawable_get_bpp
gimp_drawable_offsets -> gimp_drawable_get_offsets 

With these changes, the code should now compile.